### PR TITLE
fix: fix <lastmod> to comply with Google Sitemap requirements

### DIFF
--- a/Sitemap/Action.php
+++ b/Sitemap/Action.php
@@ -359,7 +359,7 @@ class Sitemap_Action extends Typecho_Widget implements Widget_Interface_Do
 		while ($content->next()) {
 			// 过滤隐藏分类
 			if (intval($this->mid[0]) != intval($content->categories[0]['mid'])) {
-				$xmlhtml .= "<url><loc> " . $content->permalink . "</loc><lastmod> " . date('Y-m-d H:i:s', $content->created) . " </lastmod><changefreq> " . $this->Sitemap->postChangefreq . " </changefreq><priority> " . $priority . " </priority></url>";
+				$xmlhtml .= "<url><loc> " . $content->permalink . "</loc><lastmod> " . date('Y-m-d', $content->created) . " </lastmod><changefreq> " . $this->Sitemap->postChangefreq . " </changefreq><priority> " . $priority . " </priority></url>";
 			}
 		}
 		if ($ret) {


### PR DESCRIPTION
使 `lastmod` 元素符合谷歌站点的 sitemap 要求，删除某行代码中具体的 `H:i:s` 时间，只保留 `Y-m-d`，经过测试更改之后可以成功提交谷歌（使用更改前的插件生成会报错）
![image](https://github.com/user-attachments/assets/2697d058-88d6-4f4b-a348-025d26f658ef)
